### PR TITLE
Added the skip_verification option.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,9 +10,6 @@ GOTEST=$(GO) test
 GOCOVER=$(GO) tool cover
 XCADDY=xcaddy
 
-example:
-	$(XCADDY) run -config=example/caddy.json
-
 debug:
 	XCADDY_DEBUG=1 $(XCADDY) build --with github.com/ggicci/caddy-jwt=$(shell pwd)
 
@@ -24,4 +21,4 @@ test/cover:
 test/report:
 	$(GOCOVER) -html=main.cover.out
 
-.PHONY: example debug test test/cover test/report
+.PHONY: debug test test/cover test/report

--- a/README.md
+++ b/README.md
@@ -118,10 +118,12 @@ Module **caddy-jwt** behaves like a **"JWT Validator"**. The authentication flow
    │  3. cookies      │
    └────────┬─────────┘
             │
-    ┌───────▼────────┐
-    │   is valid?    │
-    │using `sign_key`├────NO───────┐
-    └───────┬────────┘             │
+    ┌───────▼───────────┐
+    │     is valid?     │
+    │  using `sign_key` │
+    │ or validation is  │
+    │     disabled      ├─NO───────┐
+    └───────┬───────────┘          │
             │YES                   │
 ┌───────────▼───────────┐          │
 │Populate {http.user.id}│          │

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -40,6 +40,8 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 				if !h.AllArgs(&ja.JWKURL) {
 					return nil, h.Errf("invalid jwk_url: %q", ja.JWKURL)
 				}
+			case "skip_verification":
+				ja.SkipVerification = true
 			case "from_query":
 				ja.FromQuery = h.RemainingArgs()
 


### PR DESCRIPTION
This option is intended for users who prefer to verify the JWT token elsewhere while still leveraging other features provided by the module.

All the details are provided in the comment for SkipVerification in jwt.go. In short, we verify the token after the Caddy proxy in the upstreams, but we still need the other features offered by the plugin, especially parsing and populating user metadata.

Hopefully it would be useful for other people as well.

Thanks.