### PR TITLE
Add placeholder replacement support for signKey

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ hwIDAQAB
 
 6. Bypass the verification by turning on `skip_verification` option, [#85](/../../issues/85).
 
+7. Instead of specifying the `sign_key` directly as a value, you can use a feature introduced in Caddy v2.8.0 to load it from a file using `sign_key {file./path/to/sign_key.txt}`.
+
 ## How to do integration test of caddy-jwt locally?
 
 For **caddy-jwt users**, we assume you've already got a custom caddy binary built with our caddy-jwt plugin. Then you can run the test:

--- a/jwt.go
+++ b/jwt.go
@@ -513,6 +513,9 @@ func desensitizedTokenString(token string) string {
 
 // parseSignKey parses the given key and returns the key bytes.
 func parseSignKey(signKey string) (keyBytes []byte, asymmetric bool, err error) {
+	repl := caddy.NewReplacer()
+	// Replace placeholders in the signKey such as {file./path/to/sign_key.txt}
+	signKey = repl.ReplaceAll(signKey, "")
 	if len(signKey) == 0 {
 		return nil, false, ErrMissingKeys
 	}


### PR DESCRIPTION
This pull request adds [placeholder replacement support](https://caddyserver.com/docs/extending-caddy/placeholders#implementing-placeholder-support) for the `sign_key` sub-directive, allowing users to load keys from external files.

Example usage:

```Caddyfile
jwtauth {
  sign_key {file.sign_key.txt}
  sign_alg HS256
  jwk_url https://api.example.com/jwk/keys
  from_query access_token token
  from_header X-Api-Token
  from_cookies user_session
  issuer_whitelist https://api.example.com
  audience_whitelist https://api.example.io https://learn.example.com
  user_claims aud uid user_id username login
  meta_claims "IsAdmin->is_admin" "settings.payout.paypal.enabled->is_paypal_enabled"
}
```

In this example, the file `sign_key.txt` contains the actual signing key, such as:

```txt
TkZMNSowQmMjOVU2RUB0bm1DJkU3U1VONkd3SGZMbVk=
```

This update also facilitates the use of public keys by allowing direct references to `.pem` files, e.g.:

```Caddyfile
sign_key {file./path/to/public_key.pem}
```

Note
This feature requires **Caddy v2.8.0 or later**, which introduced support for the `{file.}` placeholder syntax.
See: [https://github.com/caddyserver/caddy/pull/5463](https://github.com/caddyserver/caddy/pull/5463)
