### PR TITLE
Feature/add clock skew property

### DIFF
--- a/caddyfile.go
+++ b/caddyfile.go
@@ -42,7 +42,6 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 					return nil, h.Errf("invalid jwk_url: %q", ja.JWKURL)
 				}
 			case "clock_skew":
-				ja.ClockSkew = 0
 				var clockSkewStr string
 				if !h.AllArgs(&clockSkewStr) {
 					return nil, h.Errf("invalid clock_skew: %q", ja.ClockSkew)

--- a/caddyfile.go
+++ b/caddyfile.go
@@ -2,6 +2,7 @@ package caddyjwt
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 
 	"github.com/caddyserver/caddy/v2"
@@ -39,6 +40,19 @@ func parseCaddyfile(h httpcaddyfile.Helper) (caddyhttp.MiddlewareHandler, error)
 			case "jwk_url":
 				if !h.AllArgs(&ja.JWKURL) {
 					return nil, h.Errf("invalid jwk_url: %q", ja.JWKURL)
+				}
+			case "clock_skew":
+				ja.ClockSkew = 0
+				var clockSkewStr string
+				if !h.AllArgs(&clockSkewStr) {
+					return nil, h.Errf("invalid clock_skew: %q", ja.ClockSkew)
+				} else {
+					clockSkewNumber, err := strconv.Atoi(clockSkewStr)
+					if err == nil && clockSkewNumber >= 0 {
+						ja.ClockSkew = clockSkewNumber
+					} else {
+						return nil, h.Errf("invalid clock_skew: %q, must be a non-negative integer", clockSkewStr)
+					}
 				}
 			case "skip_verification":
 				ja.SkipVerification = true

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -209,3 +209,66 @@ func TestParsingCaddyfileWithSkipVerification(t *testing.T) {
 	assert.True(t, ok)
 	assert.Equal(t, caddyconfig.JSON(expectedJA, nil), jsonConfig)
 }
+
+func TestParsingCaddyFileClockSkew(t *testing.T) {
+	helper := httpcaddyfile.Helper{
+		Dispenser: caddyfile.NewTestDispenser(`
+	jwtauth {
+		jwk_url https://example.com/.well-known/jwks.json
+		clock_skew 60
+		user_claims preferred_username
+	}
+	`),
+	}
+	expectedJA := &JWTAuth{
+		JWKURL:     "https://example.com/.well-known/jwks.json",
+		ClockSkew:  60,
+		UserClaims: []string{"preferred_username"},
+	}
+
+	h, err := parseCaddyfile(helper)
+	assert.Nil(t, err)
+	auth, ok := h.(caddyauth.Authentication)
+	assert.True(t, ok)
+	jsonConfig, ok := auth.ProvidersRaw["jwt"]
+	assert.True(t, ok)
+	assert.Equal(t, caddyconfig.JSON(expectedJA, nil), jsonConfig)
+}
+
+func TestParsingCaddyFileErrorClockSkew(t *testing.T) {
+	helper := httpcaddyfile.Helper{
+		Dispenser: caddyfile.NewTestDispenser(`
+	jwtauth {
+		clock_skew -60
+	}
+	`),
+	}
+
+	_, err := parseCaddyfile(helper)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "clock_skew")
+
+	helper = httpcaddyfile.Helper{
+		Dispenser: caddyfile.NewTestDispenser(`
+	jwtauth {
+		clock_skew
+	}
+	`),
+	}
+
+	_, err = parseCaddyfile(helper)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "clock_skew")
+
+	helper = httpcaddyfile.Helper{
+		Dispenser: caddyfile.NewTestDispenser(`
+	jwtauth {
+		clock_skew abc
+	}
+	`),
+	}
+
+	_, err = parseCaddyfile(helper)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "clock_skew")
+}

--- a/jwt.go
+++ b/jwt.go
@@ -81,6 +81,14 @@ type JWTAuth struct {
 	// 3. The value set here.
 	SignAlgorithm string `json:"sign_alg"`
 
+	// ClockSkew defines the clock skew for the "iat" (issued at),
+	// "exp" (expiration time) and "nbf" (not before) claim verification in seconds.
+	//
+	// The default value is 0, which means the claims will be verified strictly.
+	// Use with caution, as allowing a large clock skew can make the verification less secure.
+	// Time sync of all parties involved is recommended.
+	ClockSkew int `json:"clock_skew"`
+
 	// SkipVerification disables the verification of the JWT token signature.
 	//
 	// Use this option with caution, as it bypasses JWT signature verification.
@@ -406,6 +414,9 @@ func (ja *JWTAuth) Authenticate(rw http.ResponseWriter, r *http.Request) (User, 
 
 		jwtOptions := []jwt.ParseOption{
 			jwt.WithVerify(!ja.SkipVerification),
+		}
+		if ja.ClockSkew > 0 {
+			jwtOptions = append(jwtOptions, jwt.WithAcceptableSkew(time.Duration(ja.ClockSkew)*time.Second))
 		}
 		if !ja.SkipVerification {
 			jwtOptions = append(jwtOptions, jwt.WithKeyProvider(ja.keyProvider(r)))

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -7,12 +7,13 @@ import (
 	"crypto/rsa"
 	"encoding/base64"
 	"encoding/json"
-	"github.com/caddyserver/caddy/v2"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/caddyserver/caddy/v2"
 
 	"github.com/lestrrat-go/jwx/v3/jwa"
 	"github.com/lestrrat-go/jwx/v3/jwk"
@@ -213,6 +214,66 @@ func TestValidate_SkipVerification(t *testing.T) {
 		SkipVerification: true,
 	}
 	assert.NoError(t, ja.Validate())
+}
+
+func TestAuthenticate_ClockSkew_Exp(t *testing.T) {
+	claims := MapClaims{"sub": "dfeden",
+		"exp": time.Now().Add(-5 * time.Second).Unix(), // expired 5 Seconds ago
+	}
+	ja := &JWTAuth{
+		SignKey:   TestSignKey,
+		logger:    testLogger,
+		ClockSkew: 10, // allow 10 seconds of clock skew
+	}
+	assert.Nil(t, ja.Validate())
+
+	rw := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.Header.Add("Authorization", "Bearer "+issueTokenString(claims))
+	gotUser, authenticated, err := ja.Authenticate(rw, r)
+	assert.Nil(t, err)
+	assert.True(t, authenticated)
+	assert.Equal(t, "dfeden", gotUser.ID)
+}
+
+func TestAuthenticate_ClockSkew_Iat(t *testing.T) {
+	claims := MapClaims{"sub": "dfeden",
+		"iat": time.Now().Add(5 * time.Second).Unix(), // issued 5 Seconds in the future
+	}
+	ja := &JWTAuth{
+		SignKey:   TestSignKey,
+		logger:    testLogger,
+		ClockSkew: 10, // allow 10 seconds of clock skew
+	}
+	assert.Nil(t, ja.Validate())
+
+	rw := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.Header.Add("Authorization", "Bearer "+issueTokenString(claims))
+	gotUser, authenticated, err := ja.Authenticate(rw, r)
+	assert.Nil(t, err)
+	assert.True(t, authenticated)
+	assert.Equal(t, "dfeden", gotUser.ID)
+}
+
+func TestAuthenticate_ClockSkew_Nbf(t *testing.T) {
+	claims := MapClaims{"sub": "dfeden",
+		"nbf": time.Now().Add(5 * time.Second).Unix(), // issued 5 Seconds in the future
+	}
+	ja := &JWTAuth{
+		SignKey:   TestSignKey,
+		logger:    testLogger,
+		ClockSkew: 10, // allow 10 seconds of clock skew
+	}
+	assert.Nil(t, ja.Validate())
+
+	rw := httptest.NewRecorder()
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.Header.Add("Authorization", "Bearer "+issueTokenString(claims))
+	gotUser, authenticated, err := ja.Authenticate(rw, r)
+	assert.Nil(t, err)
+	assert.True(t, authenticated)
+	assert.Equal(t, "dfeden", gotUser.ID)
 }
 
 func TestValidate_InvalidMetaClaims(t *testing.T) {


### PR DESCRIPTION
while using caddy jwt in complex development environments, I faced issues with not properly synchronized clocks between token issuer and caddy deployment.

to overcome these issues I introduced a clock skew configuration parameter that is used validating exp, iat and nbf time claims.