### PR TITLE
fix: remove Authorization as default header

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -403,7 +403,7 @@ func (ja *JWTAuth) Authenticate(rw http.ResponseWriter, r *http.Request) (User, 
 	candidates = append(candidates, getTokensFromQuery(r, ja.FromQuery)...)
 	candidates = append(candidates, getTokensFromHeader(r, ja.FromHeader)...)
 	candidates = append(candidates, getTokensFromCookies(r, ja.FromCookies)...)
-	candidates = append(candidates, getTokensFromHeader(r, []string{"Authorization"})...)
+
 	checked := make(map[string]struct{})
 
 	for _, candidateToken := range candidates {

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -224,6 +224,7 @@ func TestAuthenticate_ClockSkew_Exp(t *testing.T) {
 		SignKey:   TestSignKey,
 		logger:    testLogger,
 		ClockSkew: 10, // allow 10 seconds of clock skew
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -244,6 +245,7 @@ func TestAuthenticate_ClockSkew_Iat(t *testing.T) {
 		SignKey:   TestSignKey,
 		logger:    testLogger,
 		ClockSkew: 10, // allow 10 seconds of clock skew
+		FromHeader: []string{"Authorization"}
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -298,7 +300,11 @@ func TestDetermineSigningAlgorithmFallback(t *testing.T) {
 
 func TestAuthenticate_FromAuthorizationHeader(t *testing.T) {
 	claims := MapClaims{"sub": "ggicci"}
-	ja := &JWTAuth{SignKey: TestSignKey, logger: testLogger}
+	ja := &JWTAuth{
+		SignKey: TestSignKey,
+		logger: testLogger,
+		FromHeader: []string{"Authorization"}
+	}
 	assert.Nil(t, ja.Validate())
 
 	rw := httptest.NewRecorder()
@@ -312,7 +318,12 @@ func TestAuthenticate_FromAuthorizationHeader(t *testing.T) {
 
 func TestAuthenticate_EdDSA(t *testing.T) {
 	claims := MapClaims{"sub": "ggicci"}
-	ja := &JWTAuth{SignKey: TestSignKeyEd25519, SignAlgorithm: jwa.EdDSA().String(), logger: testLogger}
+	ja := &JWTAuth{
+		SignKey: TestSignKeyEd25519,
+		SignAlgorithm: jwa.EdDSA().String(),
+		logger: testLogger,
+		FromHeader: []string{"Authorization"}
+	}
 	assert.Nil(t, ja.Validate())
 
 	rw := httptest.NewRecorder()
@@ -395,6 +406,7 @@ func TestAuthenticate_PopulateUserMetadataWithSkipVerification(t *testing.T) {
 			"settings.payout.paypal.enabled": "is_paypal_enabled",
 		},
 		logger: testLogger,
+		FromHeader: []string{"Authorization"}
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -525,6 +537,7 @@ func TestAuthenticate_CustomUserClaims(t *testing.T) {
 		SignKey:    TestSignKey,
 		UserClaims: []string{"username"},
 		logger:     testLogger,
+		FromHeader: []string{"Authorization"}
 	}
 	assert.Nil(t, ja.Validate())
 	rw := httptest.NewRecorder()
@@ -541,6 +554,7 @@ func TestAuthenticate_CustomUserClaims(t *testing.T) {
 		SignKey:    TestSignKey,
 		UserClaims: []string{"username"},
 		logger:     testLogger,
+		FromHeader: []string{"Authorization"}
 	}
 	assert.Nil(t, ja.Validate())
 	rw = httptest.NewRecorder()
@@ -557,6 +571,7 @@ func TestAuthenticate_CustomUserClaims(t *testing.T) {
 		SignKey:    TestSignKey,
 		UserClaims: []string{"uid", "user_id"},
 		logger:     testLogger,
+		FromHeader: []string{"Authorization"}
 	}
 	assert.Nil(t, ja.Validate())
 	rw = httptest.NewRecorder()
@@ -573,6 +588,7 @@ func TestAuthenticate_CustomUserClaims(t *testing.T) {
 		SignKey:    TestSignKey,
 		UserClaims: []string{"user_id", "uid"},
 		logger:     testLogger,
+		FromHeader: []string{"Authorization"}
 	}
 	assert.Nil(t, ja.Validate())
 	rw = httptest.NewRecorder()
@@ -588,6 +604,7 @@ func TestAuthenticate_ValidateStandardClaims(t *testing.T) {
 	ja := &JWTAuth{
 		SignKey: TestSignKey,
 		logger:  testLogger,
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -626,8 +643,8 @@ func TestAuthenticate_VerifyIssuerWhitelist(t *testing.T) {
 	ja := &JWTAuth{
 		SignKey: TestSignKey,
 		logger:  testLogger,
-
 		IssuerWhitelist: []string{"https://api.example.com", "https://api.github.com"},
+		FromHeader: []string{"Authorization"}
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -882,7 +899,11 @@ func TestJWK(t *testing.T) {
 
 func TestJWKSet(t *testing.T) {
 	time.Sleep(3 * time.Second)
-	ja := &JWTAuth{JWKURL: TestJWKSetURL, logger: testLogger}
+	ja := &JWTAuth{
+		JWKURL: TestJWKSetURL, 
+		logger: testLogger,
+		FromHeader: []string{"Authorization"}
+	}
 	assert.Nil(t, ja.Validate())
 
 	// Authentifier pour créer le cache

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -245,7 +245,7 @@ func TestAuthenticate_ClockSkew_Iat(t *testing.T) {
 		SignKey:   TestSignKey,
 		logger:    testLogger,
 		ClockSkew: 10, // allow 10 seconds of clock skew
-		FromHeader: []string{"Authorization"}
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -266,6 +266,7 @@ func TestAuthenticate_ClockSkew_Nbf(t *testing.T) {
 		SignKey:   TestSignKey,
 		logger:    testLogger,
 		ClockSkew: 10, // allow 10 seconds of clock skew
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -303,7 +304,7 @@ func TestAuthenticate_FromAuthorizationHeader(t *testing.T) {
 	ja := &JWTAuth{
 		SignKey: TestSignKey,
 		logger: testLogger,
-		FromHeader: []string{"Authorization"}
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -314,6 +315,20 @@ func TestAuthenticate_FromAuthorizationHeader(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, authenticated)
 	assert.Equal(t, User{ID: "ggicci"}, gotUser)
+
+	// "header" not specified
+	ja = &JWTAuth{
+		SignKey:    TestSignKey,
+		logger:     testLogger,
+	}
+	assert.Nil(t, ja.Validate())
+	rw = httptest.NewRecorder()
+	r, _ = http.NewRequest("GET", "/", nil)
+	r.Header.Add("Authorization", issueTokenString(claims))
+	gotUser, authenticated, err = ja.Authenticate(rw, r)
+	assert.Nil(t, err)
+	assert.False(t, authenticated)
+	assert.NotEqual(t, User{ID: "ggicci"}, gotUser)
 }
 
 func TestAuthenticate_EdDSA(t *testing.T) {
@@ -322,7 +337,7 @@ func TestAuthenticate_EdDSA(t *testing.T) {
 		SignKey: TestSignKeyEd25519,
 		SignAlgorithm: jwa.EdDSA().String(),
 		logger: testLogger,
-		FromHeader: []string{"Authorization"}
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -351,6 +366,15 @@ func TestAuthenticate_FromCustomHeader(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, authenticated)
 	assert.Equal(t, User{ID: "ggicci"}, gotUser)
+
+	// invalid "header"
+	rw = httptest.NewRecorder()
+	r, _ = http.NewRequest("GET", "/", nil)
+	r.Header.Add("Authorization", issueTokenString(claims))
+	gotUser, authenticated, err = ja.Authenticate(rw, r)
+	assert.Nil(t, err)
+	assert.False(t, authenticated)
+	assert.NotEqual(t, User{ID: "ggicci"}, gotUser)
 }
 
 func TestAuthenticate_FromQueryWithSkipVerification(t *testing.T) {
@@ -406,7 +430,7 @@ func TestAuthenticate_PopulateUserMetadataWithSkipVerification(t *testing.T) {
 			"settings.payout.paypal.enabled": "is_paypal_enabled",
 		},
 		logger: testLogger,
-		FromHeader: []string{"Authorization"}
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -537,7 +561,7 @@ func TestAuthenticate_CustomUserClaims(t *testing.T) {
 		SignKey:    TestSignKey,
 		UserClaims: []string{"username"},
 		logger:     testLogger,
-		FromHeader: []string{"Authorization"}
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 	rw := httptest.NewRecorder()
@@ -554,7 +578,7 @@ func TestAuthenticate_CustomUserClaims(t *testing.T) {
 		SignKey:    TestSignKey,
 		UserClaims: []string{"username"},
 		logger:     testLogger,
-		FromHeader: []string{"Authorization"}
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 	rw = httptest.NewRecorder()
@@ -571,7 +595,7 @@ func TestAuthenticate_CustomUserClaims(t *testing.T) {
 		SignKey:    TestSignKey,
 		UserClaims: []string{"uid", "user_id"},
 		logger:     testLogger,
-		FromHeader: []string{"Authorization"}
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 	rw = httptest.NewRecorder()
@@ -588,7 +612,7 @@ func TestAuthenticate_CustomUserClaims(t *testing.T) {
 		SignKey:    TestSignKey,
 		UserClaims: []string{"user_id", "uid"},
 		logger:     testLogger,
-		FromHeader: []string{"Authorization"}
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 	rw = httptest.NewRecorder()
@@ -644,7 +668,7 @@ func TestAuthenticate_VerifyIssuerWhitelist(t *testing.T) {
 		SignKey: TestSignKey,
 		logger:  testLogger,
 		IssuerWhitelist: []string{"https://api.example.com", "https://api.github.com"},
-		FromHeader: []string{"Authorization"}
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -692,9 +716,9 @@ func TestAuthenticate_VerifyAudienceWhitelist(t *testing.T) {
 	ja := &JWTAuth{
 		SignKey: TestSignKey,
 		logger:  testLogger,
-
 		IssuerWhitelist:   []string{"https://api.github.com"},
 		AudienceWhitelist: []string{"https://api.codelet.io", "https://api.copilot.codelet.io"},
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -765,6 +789,7 @@ func TestAuthenticate_PopulateUserMetadata(t *testing.T) {
 			"settings.payout.alipay.enabled": "is_alipay_enabled",
 		},
 		logger: testLogger,
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -852,7 +877,12 @@ func Test_desensitizedTokenString(t *testing.T) {
 }
 
 func Test_AsymmetricAlgorithm(t *testing.T) {
-	ja := &JWTAuth{SignKey: TestPubKey, UserClaims: []string{"login"}, logger: testLogger}
+	ja := &JWTAuth{
+		SignKey: TestPubKey,
+		UserClaims: []string{"login"},
+		logger: testLogger,
+		FromHeader: []string{"Authorization"},
+	}
 	assert.Nil(t, ja.Validate())
 	token := "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIzMDc3NTU1IiwibG9naW4iOiJnZ2ljY2kiLCJkaXNwbGF5IjoiR2dpY2NpIiwiYWRtaW4iOmZhbHNlfQ.eOXRUSS-WSebEobZgqmui9VlKentHW5IxQpWR5xGu-u9svzdWJnGqLbnKBeIy42tQkFHNDWUx4R2z8Jv3ZPByN1qvWYIloJ8vLQsb0GsfXoqOPkhsfAzkOEp0m5Ws83ar9TT83MLQrUisKU-WjRZTOid9Hfe2atKN4h74vqpNMUfdRZ4NOZtBTmKjoRdWwNBmM5kg59b_cUKNR9Ruab0dwI72_svFZaNiRzBXLTTOVP2Xn0wk_mavyo4dhP83P66mefSYNkoA4_xft3iG43Zkta5lnjV-EF9fACG8g4pugytDGAgGBsOoKZagIqDdNqQWo1e4CLP4G2kMTfGqlosLQ"
 	rw := httptest.NewRecorder()
@@ -871,7 +901,11 @@ func Test_AsymmetricAlgorithm_InvalidPubKey(t *testing.T) {
 
 func TestJWK(t *testing.T) {
 	time.Sleep(3 * time.Second)
-	ja := &JWTAuth{JWKURL: TestJWKURL, logger: testLogger}
+	ja := &JWTAuth{
+		JWKURL: TestJWKURL,
+		logger: testLogger,
+		FromHeader: []string{"Authorization"},
+	}
 	assert.Nil(t, ja.Validate())
 
 	// Le cache sera créé lors de la première authentification
@@ -902,7 +936,7 @@ func TestJWKSet(t *testing.T) {
 	ja := &JWTAuth{
 		JWKURL: TestJWKSetURL, 
 		logger: testLogger,
-		FromHeader: []string{"Authorization"}
+		FromHeader: []string{"Authorization"},
 	}
 	assert.Nil(t, ja.Validate())
 
@@ -931,7 +965,11 @@ func TestJWKSet(t *testing.T) {
 
 func TestJWKSet_KeyNotFound(t *testing.T) {
 	time.Sleep(3 * time.Second)
-	ja := &JWTAuth{JWKURL: TestJWKSetURLInapplicable, logger: testLogger}
+	ja := &JWTAuth{
+		JWKURL: TestJWKSetURLInapplicable,
+		logger: testLogger,
+		FromHeader: []string{"Authorization"},
+	}
 	assert.Nil(t, ja.Validate())
 
 	// Première requête pour créer le cache


### PR DESCRIPTION
Solves https://github.com/ggicci/caddy-jwt/issues/90. To preserve existing functionality, set `from_header Authorization `