### PR TITLE
Support string-list JWT claims such as aud in meta_claims

### DIFF
--- a/jwt.go
+++ b/jwt.go
@@ -479,6 +479,8 @@ func stringify(val interface{}) string {
 		return uv.String()
 	case time.Time:
 		return uv.UTC().Format(time.RFC3339Nano)
+	case []string:
+		return strings.Join(uv, ",")
 	}
 
 	if stringer, ok := val.(fmt.Stringer); ok {

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -658,6 +658,7 @@ func TestAuthenticate_PopulateUserMetadata(t *testing.T) {
 			"IsAdmin":                        "is_admin",
 			"registerTime":                   "registered_at",
 			"absent":                         "absent", // not found in JWT payload, final ""
+			"aud":                            "aud",    // standard claim, final "aud1,aud2,aud3"
 			"groups":                         "groups", // supported array type, final "csgo,dota2"
 			"settings.role":                  "role",   // supported nested claim, final "admin"
 			"settings.payout.paypal.enabled": "is_paypal_enabled",
@@ -671,6 +672,7 @@ func TestAuthenticate_PopulateUserMetadata(t *testing.T) {
 		"jti":          "a976475a-186a-4c1f-b182-95b3f886e2b4",
 		"sub":          "ggicci",
 		"IsAdmin":      true,
+		"aud":          []string{"aud1", "aud2", "aud3"},
 		"registerTime": time.Date(2000, 1, 2, 15, 23, 18, 0, time.UTC),
 		"groups":       []string{"csgo", "dota2"},
 		"settings": map[string]interface{}{
@@ -693,6 +695,7 @@ func TestAuthenticate_PopulateUserMetadata(t *testing.T) {
 	assert.Equal(t, "true", gotUser.Metadata["is_admin"])
 	assert.Equal(t, "2000-01-02T15:23:18Z", gotUser.Metadata["registered_at"])
 	assert.Equal(t, "", gotUser.Metadata["absent"])
+	assert.Equal(t, "aud1,aud2,aud3", gotUser.Metadata["aud"])
 	assert.Equal(t, "csgo,dota2", gotUser.Metadata["groups"])
 	assert.Equal(t, "admin", gotUser.Metadata["role"])
 	assert.Equal(t, "true", gotUser.Metadata["is_paypal_enabled"])
@@ -717,6 +720,7 @@ func Test_stringify(t *testing.T) {
 		{false, "false"},
 		{json.Number("1991"), "1991"},
 		{now, now.UTC().Format(time.RFC3339Nano)},
+		{[]string{"aud1", "aud2"}, "aud1,aud2"},
 		{[]int{1, 2, 3}, ""},                // unsupported array type
 		{ThingNotStringer{}, ""},            // unsupported custom type
 		{ThingIsStringer{}, "i'm stringer"}, // support fmt.Stringer interface


### PR DESCRIPTION
## Summary

Fix `meta_claims` population for JWT claims that are decoded as `[]string`, most notably the registered `aud` claim.

caddy-jwt currently stringifies array-like metadata only when the claim value is `[]interface{}`. This works for many private claims, but it does not work for registered claims such as `aud`, because the underlying JWT library decodes them as `[]string`.

As a result, configurations such as:

```caddyfile
jwtauth {
    audience_whitelist "aud1"
    meta_claims "aud"
}
```

successfully validate the audience, but `{http.auth.user.aud}` remains empty.

## Root Cause

The JWT library treats `aud` as a standard claim and decodes it into a dedicated string-list type, which is exposed to caddy-jwt as `[]string`.

caddy-jwt currently supports:

- `string`
- `bool`
- `json.Number`
- `time.Time`
- `[]interface{}`
- `fmt.Stringer`

but not `[]string`.

This causes `meta_claims "aud"` to resolve to an empty string instead of a comma-separated value.

## Changes

- Add `[]string` support to `stringify()`
- Add a regression test proving that `meta_claims "aud"` is populated correctly
- Extend the existing `stringify()` unit test to cover `[]string`

## Example

Given a token containing:

```json
{
  "aud": ["aud1", "aud2", "aud3"]
}
```

and this config:

```caddyfile
jwtauth {
    meta_claims "aud"
}
```

the placeholder `{http.auth.user.aud}` now resolves to `aud1,aud2,aud3`.

## Backward Compatibility

This is backward-compatible. It only adds support for an additional value type that was previously dropped during stringification.